### PR TITLE
Add scalars with tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ type BaseType =
   | "string"
   | "number"
   | "bigint"
-  | "boolean";
+  | "boolean"
+  | "scalar";
 
 type I<Code, Extra = unknown> = Readonly<
   PrettyIntersection<
@@ -1089,6 +1090,17 @@ class StringType extends Type<string> {
     into.push(this);
   }
 }
+
+class Scalar<T> extends Type<T> {
+  readonly name = "scalar";
+  genFunc(): Func<T> {
+    return (_, _mode) => true;
+  }
+  toTerminals(into: TerminalType[]): void {
+    into.push(this);
+  }
+}
+
 class BigIntType extends Type<bigint> {
   readonly name = "bigint";
   genFunc(): Func<bigint> {
@@ -1233,6 +1245,11 @@ function bigint(): Type<bigint> {
 function string(): Type<string> {
   return new StringType();
 }
+
+function scalar<T = unknown>(): Type<T> {
+  return new Scalar<T>();
+}
+
 function boolean(): Type<boolean> {
   return new BooleanType();
 }
@@ -1280,7 +1297,8 @@ type TerminalType =
   | ObjectType
   | ArrayType
   | LiteralType
-  | Optional;
+  | Optional
+  | Scalar<unknown>;
 
 export {
   never,
@@ -1297,6 +1315,7 @@ export {
   union,
   null_ as null,
   undefined_ as undefined,
+  scalar,
   lazy,
   ok,
   err,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -453,6 +453,58 @@ describe("string()", () => {
   });
 });
 
+describe("scalar()", () => {
+
+  it("accepts generics", () => {
+    const aScalar = v.scalar<string & { __scalar: unknown }>();
+    const a = "a";
+
+    const scalarValue = aScalar.parse(a);
+
+    const assignValue: { __scalar: unknown } = scalarValue;
+    const inferedType: v.Infer<typeof aScalar> = scalarValue;
+
+    expect(inferedType).equal(assignValue);
+    expect(inferedType).equal(a);
+    expect(inferedType + assignValue).equal(a + a);
+  });
+
+  it("prevents compare different types", () => {
+    const aScalar = v.scalar<string & { __aScalar: unknown }>();
+    const bScalar = v.scalar<string & { __bScalar: unknown }>();
+
+    const a = "a";
+
+    const aValue: { __aScalar: unknown } = aScalar.parse(a);
+    const bValue: v.Infer<typeof bScalar> = bScalar.parse(a);
+
+    expect(aValue).equal(bValue);
+    // should be an error here
+    // expect(aValue === bValue).equal(bValue);
+  });
+
+  it("defaults to unknown", () => {
+    const scalar = v.scalar();
+    const a = "a";
+
+    // scalarValue - unknown
+    const scalarValue = scalar.parse(a);
+    expect(scalarValue).equal(a);
+  });
+
+  it("assert should validate the scalar", () => {
+    const scalar = v.scalar().assert(() => true);
+
+    expect(scalar.parse("v")).to.equal("v");
+  }); 
+
+  it("assert should throw an error", () => {
+    const scalar = v.scalar().assert(() => false, "error");
+
+    expect(() => scalar.parse("v")).to.throw("error");
+  });
+});
+
 describe("unknown()", () => {
   it("accepts anything", () => {
     const t = v.unknown();


### PR DESCRIPTION
Hello again,

I'm using this lib for validating ids, for example `const UserId = v.string().assert((v) => regex.test(v), "Wrong userId")`. Its all good and I love it, but I don't like that I can assign `UserId` to any other id in my project. The reason for that is `UserId` is an alias for `string`.

Example time:
```
const UserId = v.string().assert((v) => regex.test(v), "Wrong userId")

// this is an alias for string meaning type UserId = string
type UserId =  v.Infer<typeof UserId>;
```

By adding this amazing scalar feature, I'm able to pass a type to which I want it to cast when parsed, therefore I'm able to differentiate different ids types in the project (could be any strings, numbers, etc). For example:

```
const aScalar = v.scalar<string & { __aScalar: unknown }>();
const bScalar = v.scalar<string & { __bScalar: unknown }>();

const aValue: v.Infer<typeof aScalar> = aScalar.parse("hearts");
const bValue: v.Infer<typeof bScalar> = bScalar.parse("hearts");

// error here 
if (aValue === bValue) { ...

// error here (pay attention to "a" and "b" inside the line)
const assigningWrongVariable: v.Infer<typeof aScalar> = bScalar.parse("hearts");

// all good here
if (aValue === aValue) { ...

// all good here
const assigningRightsVariable: v.Infer<typeof bScalar> = bScalar.parse("hearts");
```

I know this is a terrible practice to hide something behind a type which it is not, but it makes life much better. I will understand if this gets rejected, but maybe, just maybe for few people who does this in their daily work, this could be an easy answer...

If for some reason this is consider to be something legitimate, I don't know how to write tests that check types... (I have commented out lines that should test typings)

If this will be closed and forgotten I would like to talk about extending Valita API from child project. I could have an init place for valite where I could inject this stuff.

Thoughts?

Cheers,
Arturs

