### PR TITLE
Up transpilation target to es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,11 @@
     "test": "mocha --require ts-node/register tests/**/*.test.ts",
     "build": "rm -rf dist/* && npm run build:types && npm run build:cjs && npm run build:mjs && npm run build:node-mjs && npm run build:node-cjs",
     "build:types": "tsc -p ./tsconfig.build.json --emitDeclarationOnly --declaration --declarationMap --declarationDir ./dist/types",
-    "build:cjs": "tsc -p ./tsconfig.build.json --target es5 --module commonjs --outDir ./dist/cjs",
-    "build:mjs": "tsc -p ./tsconfig.build.json --target es5 --module es2015 --outDir ./dist/mjs && mv ./dist/mjs/index.js ./dist/mjs/index.mjs",
+    "build:cjs": "tsc -p ./tsconfig.build.json --target es2015 --module commonjs --outDir ./dist/cjs",
+    "build:mjs": "tsc -p ./tsconfig.build.json --target es2015 --module es2015 --outDir ./dist/mjs && mv ./dist/mjs/index.js ./dist/mjs/index.mjs",
     "build:node-mjs": "tsc -p ./tsconfig.build.json --target es2019 --module es2015 --outDir ./dist/node-mjs && mv ./dist/node-mjs/index.js ./dist/node-mjs/index.mjs",
     "build:node-cjs": "tsc -p ./tsconfig.build.json --target es2019 --module commonjs --outDir ./dist/node-cjs",
     "prepack": "npm run build"
-  },
-  "dependencies": {
-    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.19",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es5"
+    "target": "ES2015"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This allows us to get rid of `tslib` as a dependency and be fully self-contained. That broke our ESM support as `tslib` is not ready for ESM yet.

Fixes this error:
<img width="774" alt="Screenshot 2021-10-08 at 15 44 10" src="https://user-images.githubusercontent.com/1062408/136567893-f79a163c-0f03-4ade-b5b0-222a81ef9dfd.png">

Upping the transpilation target avoids us getting into the situation in the first place. The only browser that doesn't support ES2015 at this point seems to be IE11.

