### PR TITLE
fix: allow type checking to work with native Node16 Typescript ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     "node": {
+      "types": "./dist/types/index.d.ts",
       "module": "./dist/node-mjs/index.mjs",
       "import": "./dist/node-mjs/index.mjs",
       "require": "./dist/node-cjs/index.js"


### PR DESCRIPTION
With the introduction of [Typescript 4.7](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/) native ESM support for Node is officially available when using the Node16 "module" and "moduleResolution" options. This, however, requires a small change in the package.json "exports" field to allow types to flow through correctly as documented [here](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing).

This PR makes that small change.