### PR TITLE
Add package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/mjs/index.mjs",
   "types": "./dist/types/index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     "node": {
       "types": "./dist/types/index.d.ts",
       "module": "./dist/node-mjs/index.mjs",


### PR DESCRIPTION
Missing package.json in "exports" creates warning in react-native. See https://github.com/uuidjs/uuid/issues/444 for context