### PR TITLE
docs: add object validation coveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,35 @@ const schema = v.object({
 });
 ```
 
+### Object validation caveats
+
+With the `.shape` properties, you can validate the properties of an object using a previously defined scheme.
+
+```js
+const userSchema = v.object({
+  name: v.string()
+})
+
+const name = userSchema.shape.name.parse('me')
+```
+
+However, if you use `userSchema.assert(...)`, then you lose the ability to validate properties. This is intentional because `.assert(...)` can change the output type, but ``.shape`` cannot reflect this at runtime. For example:
+
+```js
+function isName(x: string): x is { veryStrangeObject: boolean } {
+  return true;
+}
+
+const schema = userSchema.assert(isName);
+
+// @ts-expect-error breaks .shape type
+// schema['shape] is unknown
+```
+
+For this case, object types have a special method `.check(...)`, which acts similarly to `.assert(...)`, but cannot change the output type and thus preserves `.shape`
+
+*Please note* that `.check(...)` also has caveats. For example, `.omit(...)`, `.pick(...)`, `.partial()`, and `.extend(...)` do not preserve checks.
+
 ### Recursive Types
 
 One strong suit of valita is its ability to parse types that references itself, like `type T = string | T[]`. We can express such a shape with valita using the `.lazy()` method.


### PR DESCRIPTION
Added a section to readme.md where I write about object validation coveats