### PR TITLE
Allow pass schema to .chain method [ready]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,10 +331,10 @@ abstract class AbstractType<Output = unknown> {
   }
 
   chain<T extends Literal>(func: (v: Output) => ValitaResult<T>): Type<T>;
-  chain<T>(func: (v: Output) => ValitaResult<T>): Type<T>;
+  chain<T extends Type>(type: T): T;
   chain<T>(func: (v: Output) => ValitaResult<T>): Type<T> {
     return new TransformType(this, (v) => {
-      const r = func(v as Output);
+      const r = func instanceof Type ? func.try(v) : func(v as Output);
       return r.ok ? r : (r as unknown as { issueTree: IssueTree }).issueTree;
     });
   }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -288,6 +288,13 @@ describe("Type", () => {
       expect(t.parse("a")).to.equal("a");
       expect(() => t.parse(1)).to.throw(v.ValitaError);
     });
+    it("works just by passing another type", () => {
+      const a = v.unknown();
+      const b = a.chain(v.number());
+
+      expectType(b).toImply<number>(true);
+      expect(b.try("hello").ok).toBe(true);
+    });
   });
   describe("optional()", () => {
     it("accepts missing values", () => {


### PR DESCRIPTION
This PR introduces a new way for using chain, just by passing another type/schema. It makes valita a little faster (at schema initial definition ;-D), and reduces my boilerplate code, where i should define input type, output type, and intermediate type (for business code).

```JS
// 
it("works just by passing another type", () => {
   const a = v.unknown();
   const b = a.chain(v.number());
   
   expectType(b).toImply<number>(true);
   expect(b.try("hello").ok).toBe(true);
});
```