### PR TITLE
Move .optional() to Type

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -308,6 +308,10 @@ describe("Type", () => {
       });
       expect(t.parse({ a: "test" })).to.deep.equal({ a: "test" });
     });
+    it("can be used without object", () => {
+      const schema = v.string().optional();
+      expect(schema.try(undefined).ok).toBe(true);
+    });
     it("adds undefined to output", () => {
       const t = v.string().optional();
       expectType(t).toImply<string | undefined>(true);


### PR DESCRIPTION
This PR moves `.optional()` and `.default()` from AbstractType to Type. This allows:

1. Use `.optional()` with non-fields values. It works as `T | undefined` for `T` and `{ T?: undefined }` for object fields. (zod also works that way)
2.  Use `schema.optional()` for parsing incoming values. (also, this was only one type that returns AbstractType, not Type)

It's ok if you want to choose not to take that PR.  In that case I'll just use my fork :-) Thank you for your work <3

 